### PR TITLE
Support Decision (diamond) shape conversion (#9)

### DIFF
--- a/drawio2pptx/main.py
+++ b/drawio2pptx/main.py
@@ -77,6 +77,9 @@ def main():
         # Save
         prs.save(output_path)
         print(f"Saved {output_path} ({slide_count} slides)")
+
+        # Post-process: remove BPMN symbol line effects (e.g., shadows)
+        writer.post_process_bpmn_symbol_effects(output_path)
         
         # Display warnings
         warnings = logger.get_warnings()

--- a/drawio2pptx/mapping/shape_map.py
+++ b/drawio2pptx/mapping/shape_map.py
@@ -35,6 +35,7 @@ _SHAPE_TYPE_MAP: dict[str, MSO_SHAPE] = {
     'predefinedprocess': MSO_SHAPE.FLOWCHART_PREDEFINED_PROCESS,
     'predefined_process': MSO_SHAPE.FLOWCHART_PREDEFINED_PROCESS,
     'predefined-process': MSO_SHAPE.FLOWCHART_PREDEFINED_PROCESS,
+    'decision': MSO_SHAPE.FLOWCHART_DECISION,
     # Polygon shapes
     'hexagon': MSO_SHAPE.HEXAGON,
     'pentagon': MSO_SHAPE.REGULAR_PENTAGON,

--- a/drawio2pptx/model/intermediate.py
+++ b/drawio2pptx/model/intermediate.py
@@ -80,6 +80,8 @@ class Style:
     swimlane_line: Optional[bool] = None
     # Explicitly disable stroke (e.g. draw.io text shapes, strokeColor=none)
     no_stroke: bool = False
+    # BPMN symbol (e.g., 'parallelGw' for parallel gateway)
+    bpmn_symbol: Optional[str] = None
 
 
 @dataclass


### PR DESCRIPTION
Fixes #9

## Summary
Add support for Decision (diamond) shapes so they are converted correctly from draw.io to pptx.

## Details
- Add handling for Decision (diamond) shapes during conversion
- Ensure connectors originating from Decision shapes are processed correctly
- Prevent connectors from being rendered with invalid source positions when Decision shapes are present